### PR TITLE
Fix the issue with the missing entry in the sparsity pattern.

### DIFF
--- a/source/SAND.cc
+++ b/source/SAND.cc
@@ -406,7 +406,7 @@ namespace SAND
       constraints.close ();
 
       DoFTools::make_sparsity_pattern (dof_handler, coupling, dsp, constraints,
-          false);
+          true);
 
       sparsity_pattern.copy_from (dsp);
 


### PR DESCRIPTION
This lets your program run through. You probably will want to read up on what that last parameter does.

The underlying reason, I think, is that you are using a sort of non-standard way to copy local entries into the global matrix. Put your boundary values into the `constraint` object instead of the `boundary_values` map, and then use `constraints.copy_local_to_global()` like we do in most other tutorial programs.